### PR TITLE
Safety check: Avoid infinite loops

### DIFF
--- a/hoodie/server/handle-user-change.js
+++ b/hoodie/server/handle-user-change.js
@@ -10,7 +10,15 @@ function handleUserChange (server, store, eventName, doc) {
     return
   }
 
-  server.log(['info', 'change'], `${doc._id} by ${doc.hoodie.createdAt}`)
+  const dbName = store.db.name
+  const revision = parseInt(doc._rev, 10)
+
+  if (revision > 10) {
+    server.log(['error', 'change'], `${dbName}/${doc._id} has revision higher than 10. Ignoring to avoid unwanted infinite-loop changes.`)
+    return
+  }
+
+  server.log(['info', 'change'], `${dbName}/${doc._id} by ${doc.hoodie.createdAt}`)
   var noteId = toDocId(doc)
 
   if (isSpeech(doc)) {


### PR DESCRIPTION
There was a bug in the code which led to doing infinite sentiment analysis. We know ignore all documents with revisions higher than 10 and log an error instead